### PR TITLE
3 add docker image build to release workflow

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,0 +1,16 @@
+name: On push, deploying to Test
+
+on: [push]
+
+jobs:
+  run-build-and-deploy:
+    uses: octopusden/octopus-base/.github/workflows/common-py-build-deploy.yml@main
+    with:
+      process_env: Test
+    secrets: inherit
+
+  build-push-docker-image:
+    uses: octopusden/octopus-base/.github/workflows/common-docker-build-deploy.yml@main
+    with:
+      tags: |
+        ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,20 @@
+name: On Release, deploying to Prod
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  run-build-and-deploy:
+    uses: octopusden/octopus-base/.github/workflows/common-py-build-deploy.yml@main
+    with:
+      process_env: Prod
+    secrets: inherit
+
+  build-push-docker-image:
+    uses: octopusden/octopus-base/.github/workflows/common-docker-build-deploy.yml@main
+    with:
+      tags: |
+        ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+        ghcr.io/${{ github.repository }}:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
-ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}
+FROM debian:bullseye
 
 USER root
-RUN apt-get --quiet --assume-yes update && apt-get --quiet --assume-yes install sqlite3
+
+# "psycopg2" will not be installed correctly without 'libpq-dev' and 'build-essential'
+
+RUN apt-get --quiet --assume-yes update && \
+    apt-get --no-install-recommends --quiet --assume-yes install \
+        python3-pysvn \
+        python3-pip \
+        python3-dev \
+        libpq-dev \
+        build-essential \
+        libmagic1 && \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade setuptools wheel
+
 RUN rm -rf /build
 COPY --chown=root:root . /build
 WORKDIR /build
-RUN python -m pip install $(pwd) && python -m unittest discover -v && python setup.py bdist_wheel
-ENTRYPOINT ["python", "-m", "oc_checksums_worker"]
+RUN python3 -m pip install $(pwd) && \
+    python3 -m unittest discover -v && \
+    python3 setup.py bdist_wheel
+
+ENTRYPOINT ["python3", "-m", "oc_checksums_worker"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Checksums/DLContents worker for registring different artifacts in PSQL database basing on *AMQP* queue messages.
+**Checksums/DLContents** worker for registring different artifacts in PSQL database basing on *AMQP* queue messages.
 
 ## Limitations
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "2.0.2"
+__version = "2.0.3"
 
 setup(name="oc-checksums-worker",
         version=__version,


### PR DESCRIPTION
- Added `.github/actions` for building and deploying *PyPI* package and *Docker* image.
- Changed `Dockerfile` to build from `debian` image instead of `python` (which is based on `debian` also) - because of binary dependencies.
- Documentation appended and re-formatted for pretty-view.