### PR TITLE
7 worker fails to download large files due to lack of memory

### DIFF
--- a/oc_checksums_worker/checksums_worker.py
+++ b/oc_checksums_worker/checksums_worker.py
@@ -238,7 +238,7 @@ class QueueWorkerApplication(ChecksumsQueueServer):
         _result = tempfile.NamedTemporaryFile()
         logging.info("Downloading '%s' to '%s'" % (gav, _result.name))
         try:
-            mvn_client.cat(gav, binary=True, write_to=_result)
+            mvn_client.cat(gav, binary=True, stream=True, write_to=_result)
         except Exception as _e:
             # we have to close tempfile in case of failure due to 'tempfile' module feature
             _result.close()

--- a/oc_checksums_worker/tests/test_application.py
+++ b/oc_checksums_worker/tests/test_application.py
@@ -364,7 +364,7 @@ class WorkerLogicTest(unittest.TestCase):
         _wrk = QueueWorkerApplicationMock(setup_orm=False, controller=unittest.mock.MagicMock())
         _mvn = unittest.mock.MagicMock()
         _wrk._download(_mvn, "G:A:V:P")
-        _mvn.cat.assert_called_once_with("G:A:V:P", binary=True, write_to=AnyTempFile())
+        _mvn.cat.assert_called_once_with("G:A:V:P", binary=True, stream=True, write_to=AnyTempFile())
 
     def test_check_artifact_not_registered__no_checksum(self):
         _ctrl = unittest.mock.MagicMock()

--- a/oc_checksums_worker/tests/test_logic_citypes.py
+++ b/oc_checksums_worker/tests/test_logic_citypes.py
@@ -162,8 +162,10 @@ class RegistrationCiTypesTest(archive_test_case.ArchiveTestCase):
             _gavs.append(_gav)
 
         for _gav in _gavs:
-            self.register(_gav, citype="AWFUL")
             self.check_counters(Files=0, CheckSums=0, Locations=0, HistoricalLocations=0)
-            self.assertIsNone(self.ck_controller.get_file_by_location(_gav, "NXS"))
+            self.register(_gav, citype="AWFUL")
+            self.check_counters(Files=1, CheckSums=1, Locations=1, HistoricalLocations=1)
+            _file = self.ck_controller.get_file_by_location(_gav, "NXS")
+            self.assertEqual(_file.ci_type.code, "FILE")
 
 

--- a/oc_checksums_worker/tests/test_logic_citypes.py
+++ b/oc_checksums_worker/tests/test_logic_citypes.py
@@ -34,14 +34,14 @@ class RegistrationCiTypesTest(archive_test_case.ArchiveTestCase):
         _gav_zip = 'test:archive:0.1:zip'
         self.mvn.create_gav(_gav_txt)
         self.register(gav=_gav_txt, citype="NONEXIST", depth=0)
-        self.check_counters(Files=0, CheckSums=0, Locations=0, HistoricalLocations=0)
-        self.assertIsNone(self.ck_controller.get_file_by_location(_gav_txt, "NXS"))
+        _file = self.ck_controller.get_file_by_location(_gav_txt, "NXS"))
+        self.assertEqual(_file.ci_type.code, "FILE")
 
         # now pack this into an archive, ci_type shuld not be set to 'FILE' while registering an archive
         # note the count of locations to check - one lower than previous
         self.mvn.create_gav(_gav_zip, include=generate_many_different_gavs(1, p='txt', current=['test:file:0.1:txt']))
         self.register_check(gav=_gav_zip, depth=1)
-        self.check_counters(Files=3, CheckSums=3, Locations=3, HistoricalLocations=3)
+        self.check_counters(Files=3, CheckSums=3, Locations=4, HistoricalLocations=3)
         self.assertEqual(
                 self.ck_controller.get_file_by_checksum(self.mvn.info(_gav_txt).get("md5")).ci_type.code, "FILE")
 
@@ -162,12 +162,11 @@ class RegistrationCiTypesTest(archive_test_case.ArchiveTestCase):
             _gavs.append(_gav)
 
         self.check_counters(Files=0, CheckSums=0, Locations=0, HistoricalLocations=0)
-        _idx = 0
 
         for _gav in _gavs:
             self.register(_gav, citype="AWFUL")
-            _idx +=1
-            self.check_counters(Files=_idx, CheckSums=_idx, Locations=_idx, HistoricalLocations=_idx)
+            # should be registered as 'FILE'
+            # since we have the same file for first 3 cases then counters shoud differ
             _file = self.ck_controller.get_file_by_location(_gav, "NXS")
             self.assertEqual(_file.ci_type.code, "FILE")
 

--- a/oc_checksums_worker/tests/test_logic_citypes.py
+++ b/oc_checksums_worker/tests/test_logic_citypes.py
@@ -41,7 +41,7 @@ class RegistrationCiTypesTest(archive_test_case.ArchiveTestCase):
         # note the count of locations to check - one lower than previous
         self.mvn.create_gav(_gav_zip, include=generate_many_different_gavs(1, p='txt', current=['test:file:0.1:txt']))
         self.register_check(gav=_gav_zip, depth=1)
-        self.check_counters(Files=3, CheckSums=3, Locations=4, HistoricalLocations=3)
+        self.check_counters(Files=3, CheckSums=3, Locations=4, HistoricalLocations=4)
         self.assertEqual(
                 self.ck_controller.get_file_by_checksum(self.mvn.info(_gav_txt).get("md5")).ci_type.code, "FILE")
 

--- a/oc_checksums_worker/tests/test_logic_citypes.py
+++ b/oc_checksums_worker/tests/test_logic_citypes.py
@@ -34,7 +34,7 @@ class RegistrationCiTypesTest(archive_test_case.ArchiveTestCase):
         _gav_zip = 'test:archive:0.1:zip'
         self.mvn.create_gav(_gav_txt)
         self.register(gav=_gav_txt, citype="NONEXIST", depth=0)
-        _file = self.ck_controller.get_file_by_location(_gav_txt, "NXS"))
+        _file = self.ck_controller.get_file_by_location(_gav_txt, "NXS")
         self.assertEqual(_file.ci_type.code, "FILE")
 
         # now pack this into an archive, ci_type shuld not be set to 'FILE' while registering an archive

--- a/oc_checksums_worker/tests/test_logic_citypes.py
+++ b/oc_checksums_worker/tests/test_logic_citypes.py
@@ -161,10 +161,13 @@ class RegistrationCiTypesTest(archive_test_case.ArchiveTestCase):
             self.mvn.create_gav(_gav)
             _gavs.append(_gav)
 
+        self.check_counters(Files=0, CheckSums=0, Locations=0, HistoricalLocations=0)
+        _idx = 0
+
         for _gav in _gavs:
-            self.check_counters(Files=0, CheckSums=0, Locations=0, HistoricalLocations=0)
             self.register(_gav, citype="AWFUL")
-            self.check_counters(Files=1, CheckSums=1, Locations=1, HistoricalLocations=1)
+            _idx +=1
+            self.check_counters(Files=_idx, CheckSums=_idx, Locations=_idx, HistoricalLocations=_idx)
             _file = self.ck_controller.get_file_by_location(_gav, "NXS")
             self.assertEqual(_file.ci_type.code, "FILE")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "2.0.3"
+__version = "2.0.4"
 
 setup(name="oc-checksums-worker",
         version=__version,


### PR DESCRIPTION
closes #7 
closes #6 

- added `stream` mode to `mvn.cat` method
- unit-tests fixed